### PR TITLE
[ci skip] adding user @username

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @asjohnston-asf @jhkennedy @jlrine2
+* @username

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - username
     - jhkennedy
     - asjohnston-asf
     - jlrine2


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @username as instructed in #1.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #1